### PR TITLE
dbus-gen: misc changes found when generating the Haskell bindings

### DIFF
--- a/go-idl.go
+++ b/go-idl.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-3-Clause
+package main
+
+var goSingleSigMap = map[string]string{
+	"y": "byte",
+	"b": "bool",
+	"n": "int16",
+	"q": "uint16",
+	"i": "int32",
+	"u": "uint32",
+	"x": "int64",
+	"t": "uint64",
+	"d": "float64",
+	"s": "string",
+	"o": "dbus.ObjectPath",
+	"v": "dbus.Variant",
+	"h": "unixFDIndex",
+}
+
+var goDoubleSigMap = map[string]string{
+	"ay": "[]byte",
+	"ai": "[]int32",
+	"au": "[]uint32",
+	"at": "[]uint64",
+	"as": "[]string",
+	"ao": "[]dbus.ObjectPath",
+}
+
+var goComplexSigMap = map[string]string{
+	"a{ss}":     "map[string]string",
+	"a{sv}":     "map[string]dbus.Variant",
+	"aa{ss}":    "[]map[string]string",
+	"aa{sv}":    "[]map[string]dbus.Variant",
+	"a{sa{sv}}": "map[string]map[string]dbus.Variant",
+}
+
+func GoType(dt string) string {
+	if t, ok := goSingleSigMap[dt]; ok {
+		return t
+	}
+	if t, ok := goDoubleSigMap[dt]; ok {
+		return t
+	}
+	if t, ok := goComplexSigMap[dt]; ok {
+		return t
+	}
+	return "interface{}"
+}
+
+func (a Arg) GoType() string {
+        return GoType(a.Type)
+}
+
+func (p Property) GoType() string {
+        return GoType(p.Type)
+}

--- a/go-idl.go
+++ b/go-idl.go
@@ -28,6 +28,7 @@ var goDoubleSigMap = map[string]string{
 
 var goComplexSigMap = map[string]string{
 	"a{ss}":     "map[string]string",
+	"a{su}":     "map[string]uint32",
 	"a{sv}":     "map[string]dbus.Variant",
 	"aa{ss}":    "[]map[string]string",
 	"aa{sv}":    "[]map[string]dbus.Variant",

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/apertussolutions/dbus-gen
+
+go 1.11
+
+require github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/idl.go
+++ b/idl.go
@@ -9,7 +9,7 @@ import (
 )
 
 type DocString struct {
-	XMLName xml.Name `xml:"http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0 docstring"`
+	XMLName xml.Name `xml:"docstring"`
 	Body    string   `xml:",innerxml"`
 }
 

--- a/idl.go
+++ b/idl.go
@@ -20,52 +20,6 @@ type Arg struct {
 	Direction string   `xml:"direction,attr"`
 }
 
-var singleSigMap = map[string]string{
-	"y": "byte",
-	"b": "bool",
-	"n": "int16",
-	"q": "uint16",
-	"i": "int32",
-	"u": "uint32",
-	"x": "int64",
-	"t": "uint64",
-	"d": "float64",
-	"s": "string",
-	"o": "dbus.ObjectPath",
-	"v": "dbus.Variant",
-	"h": "unixFDIndex",
-}
-
-var doubleSigMap = map[string]string{
-	"ay": "[]byte",
-	"ai": "[]int32",
-	"au": "[]uint32",
-	"at": "[]uint64",
-	"as": "[]string",
-	"ao": "[]dbus.ObjectPath",
-}
-
-var complexSigMap = map[string]string{
-	"a{ss}":     "map[string]string",
-	"a{sv}":     "map[string]dbus.Variant",
-	"aa{ss}":    "[]map[string]string",
-	"a(sa{sv})": "map[string]map[string]dbus.Variant",
-}
-
-func (a Arg) GoType() string {
-
-	if t, ok := singleSigMap[a.Type]; ok {
-		return t
-	}
-	if t, ok := doubleSigMap[a.Type]; ok {
-		return t
-	}
-	if t, ok := complexSigMap[a.Type]; ok {
-		return t
-	}
-	return "interface{}"
-}
-
 type Method struct {
 	XMLName xml.Name  `xml:"method"`
 	Name    string    `xml:"name,attr"`

--- a/template-functions.go
+++ b/template-functions.go
@@ -60,8 +60,6 @@ func CamelCase(name string, private bool) string {
 		delim = "_"
 	}
 
-	name = addSplit(name, "xen", delim)
-
 	words := strings.Split(name, delim)
 
 	for i, w := range words {

--- a/template-functions.go
+++ b/template-functions.go
@@ -46,21 +46,12 @@ func removeSplit(name, token, delim string) string {
 	return name
 }
 
+func SplitCamelCase(r rune) bool {
+	return r == '.' || r == '-' || r == '_'
+}
+
 func CamelCase(name string, private bool) string {
-	var delim string
-
-	switch {
-	case strings.Contains(name, "."):
-		delim = "."
-	case strings.Contains(name, "-"):
-		delim = "-"
-	case strings.Contains(name, "_"):
-		delim = "_"
-	default:
-		delim = "_"
-	}
-
-	words := strings.Split(name, delim)
+	words := strings.FieldsFunc(name, SplitCamelCase)
 
 	for i, w := range words {
 		words[i] = strings.Title(w)


### PR DESCRIPTION
Small changes to the existing sources that were motivated by the OpenXT Haskell bindings generation.
- Separate idl implementation sources by languages. It is unlikely any will be compatible cross languages. If some function is, it sounds like it should be in the generic idl.go.
- Ignore the XML namespace value. This might be OpenXT specific? Different IDLs are using different namespaces for the DBus interfaces (`_` and `tp`). I have seen no collision so far.
- Names like `Xenclient` are not camelised around `xen` in the existing sources when using the generator for OpenXT consumption. Remove this special case.
- NetworkManager defines an  unknown type for `go-idl.go`, add it.
- Some IDLs will have to be formated on both '.' and '_' (e,g. rpc-proxy). It seems this can be the default behavior, so make it so.
- Add go.mod and go.sum to make things easier for go 1.11+ users. 1.11+ is desirable notably for: https://golang.org/doc/go1.11#text/template.
